### PR TITLE
Fix error in Adc_Seqr::begin() call in example

### DIFF
--- a/examples/ADC_SEQR_example/ADC_SEQR_example.ino
+++ b/examples/ADC_SEQR_example/ADC_SEQR_example.ino
@@ -3,7 +3,7 @@
 
 void setup() {
   Serial.begin(9600); 
-  Adc_Seqr::begin(1); //initiate sequencer, have to be before 'analogReadResolution' call to not reset it to 10
+  Adc_Seqr::begin(); //initiate sequencer, have to be before 'analogReadResolution' call to not reset it to 10
   analogReadResolution(12);
   Adc_Seqr::printSetup();
 }


### PR DESCRIPTION
`Adc_Seqr::begin()` does not have any parameters.